### PR TITLE
Improve version detection (tags) and ts(x) detection

### DIFF
--- a/jupyterlab_translate/utils.py
+++ b/jupyterlab_translate/utils.py
@@ -83,6 +83,15 @@ def get_version(repo_root_path, project):
 
         version = data.get("version", "")
 
+    if os.path.exists(repo_root_path) and not version:
+        args = ["git", "describe", "--tags", "--abbrev=0"]
+        try:
+            version = subprocess.check_output(args, cwd=repo_root_path).decode('utf-8').strip()
+            if version.startswith('v'):
+                version = version[1:]
+        except Exception:
+            pass
+
     return version
 
 
@@ -208,7 +217,7 @@ def find_source_files(
 
 # --- .pot and .po generation
 # ----------------------------------------------------------------------------
-def extract_tsx_strings(input_path):
+def extract_tsx_strings(input_path, pattern_path="**"):
     """
     Use gettext-extract to extract strings from TSX files.
 
@@ -216,16 +225,14 @@ def extract_tsx_strings(input_path):
     ----------
     temp_output_path: str
         FIXME:
+    pattern_path: str
+        prefix for pattern of paths to include
 
     Returns
     -------
     str
         FIXME:
     """
-    if input_path.split(os.sep)[-1] == "jupyterlab":
-        pattern_path = "packages"
-    else:
-        pattern_path = "src"
 
     __, output_path = tempfile.mkstemp(suffix=".pot")
     if "~" in input_path:
@@ -282,8 +289,8 @@ def extract_tsx_strings(input_path):
                 },
             ],
             "glob": {
-                "pattern": f"{pattern_path}/**/*.ts*(x)",
-                "options": {"ignore": f"{pattern_path}/**/*.spec.ts"},
+                "pattern": f"{pattern_path}/*.ts*(x)",
+                "options": {"ignore": f"{pattern_path}/*.spec.ts"},
             },
             "comments": {"otherLineLeading": True},
         },

--- a/jupyterlab_translate/utils.py
+++ b/jupyterlab_translate/utils.py
@@ -86,8 +86,12 @@ def get_version(repo_root_path, project):
     if os.path.exists(repo_root_path) and not version:
         args = ["git", "describe", "--tags", "--abbrev=0"]
         try:
-            version = subprocess.check_output(args, cwd=repo_root_path).decode('utf-8').strip()
-            if version.startswith('v'):
+            version = (
+                subprocess.check_output(args, cwd=repo_root_path)
+                .decode("utf-8")
+                .strip()
+            )
+            if version.startswith("v"):
                 version = version[1:]
         except Exception:
             pass
@@ -217,7 +221,7 @@ def find_source_files(
 
 # --- .pot and .po generation
 # ----------------------------------------------------------------------------
-def extract_tsx_strings(input_path, pattern_path="**"):
+def extract_tsx_strings(input_path):
     """
     Use gettext-extract to extract strings from TSX files.
 
@@ -225,8 +229,6 @@ def extract_tsx_strings(input_path, pattern_path="**"):
     ----------
     temp_output_path: str
         FIXME:
-    pattern_path: str
-        prefix for pattern of paths to include
 
     Returns
     -------
@@ -289,8 +291,8 @@ def extract_tsx_strings(input_path, pattern_path="**"):
                 },
             ],
             "glob": {
-                "pattern": f"{pattern_path}/*.ts*(x)",
-                "options": {"ignore": f"{pattern_path}/*.spec.ts"},
+                "pattern": "**/*.ts*(x)",
+                "options": {"ignore": "{examples/**/*.ts*(x),**/*.spec.ts}"},
             },
             "comments": {"otherLineLeading": True},
         },


### PR DESCRIPTION
Addresses #4 and allow to extract strings from `ts(x)` files whether located in `src/`, `packages/`, or elsewhere, ignoring those that are in `examples/` (or test files - as before).