### PR TITLE
Extract menu labels and labels from definitions

### DIFF
--- a/tests/example.json
+++ b/tests/example.json
@@ -1,0 +1,66 @@
+{
+  "title": "Text Editor",
+  "description": "Text editor settings.",
+  "jupyter.lab.setting-icon-label": "Editor",
+  "jupyter.lab.menus": {
+    "main": [
+      {
+        "id": "jp-mainmenu-settings",
+        "items": [
+          {
+            "type": "submenu",
+            "submenu": {
+              "id": "jp-mainmenu-settings-fileeditorindent",
+              "label": "Text Editor Indentation",
+              "items": [
+                {
+                  "command": "fileeditor:change-tabs",
+                  "args": {
+                    "insertSpaces": false,
+                    "size": 4
+                  }
+                }
+              ]
+            },
+            "rank": 30
+          }
+        ]
+      }
+    ],
+    "context": [
+      {
+        "command": "fileeditor:undo",
+        "selector": ".jp-FileEditor",
+        "rank": 1
+      }
+    ]
+  },
+  "jupyter.lab.toolbars": {
+    "Editor": []
+  },
+  "jupyter.lab.transform": true,
+  "properties": {
+    "editorConfig": {
+      "title": "Editor Configuration",
+      "description": "The configuration for all text editors.\nIf `fontFamily`, `fontSize` or `lineHeight` are `null`,\nvalues from current theme are used.",
+      "$ref": "#/definitions/editorConfig",
+      "default": {
+        "cursorBlinkRate": 530
+      }
+    }
+  },
+  "type": "object",
+  "definitions": {
+    "editorConfig": {
+      "properties": {
+        "cursorBlinkRate": {
+          "type": "number",
+          "title": "Cursor blinking rate",
+          "description": "Half-period in milliseconds used for cursor blinking. The default blink rate is 530ms. By setting this to zero, blinking can be disabled. A negative value hides the cursor entirely."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,26 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
+import json
+from jupyterlab_translate.utils import _extract_schema_strings
 
 
 def test_todo():
     assert True
+
+
+def test_extract_from_settings():
+    with open("tests/example.json") as f:
+        data = f.read()
+    lines = data.splitlines()
+    schema = json.loads(data)
+
+    entries = _extract_schema_strings(schema, lines, "example.json")
+    strings = {entry["msgid"] for entry in entries}
+    assert strings == {
+        "The configuration for all text editors.</br/>If `fontFamily`, `fontSize` or `lineHeight` are `null`,</br/>values from current theme are used.",
+        "Text Editor Indentation",
+        "Text Editor",
+        "Editor",
+        "Editor Configuration",
+        "Text editor settings.",
+    }


### PR DESCRIPTION
Addresses #1 and https://github.com/jupyterlab/jupyterlab/issues/10414 and the current lack of menu labels in Crowdin.

@fcollonval this is just a quick draft. We would need to re-use the same `to_translate` list (and some helper functions) in `jupyterlab-server` to actually swap the settings as proposed in https://github.com/jupyterlab/jupyterlab/pull/10752#issuecomment-903298283.

What do you think?