### PR TITLE
Remove transient conversion of `\n` to `</br/>`

### DIFF
--- a/jupyterlab_translate/utils.py
+++ b/jupyterlab_translate/utils.py
@@ -349,11 +349,10 @@ def _extract_schema_strings(
                     matched = True
                     break
             if matched:
-                text = value.replace("\n", "</br/>")
                 entries.append(
                     dict(
                         msgctxt=context,
-                        msgid=text,
+                        msgid=value,
                         occurrences=[(ref_path, path)],
                     )
                 )
@@ -560,7 +559,7 @@ def remove_duplicates(pot_path: Path, metadata: Dict[str, str]) -> None:
 
     po.save(str(pot_path))
 
-    pot_path.write_text(pot_path.read_text().replace(r"</br/>", r"\n"))
+    pot_path.write_text(pot_path.read_text())
 
     old_pot_name.unlink()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -76,7 +76,7 @@ def test_extract_from_settings():
         for entry in _extract_schema_strings(schema, "example.json")
     }
     assert set(entries.keys()) == {
-        "The configuration for all text editors.</br/>If `fontFamily`, `fontSize` or `lineHeight` are `null`,</br/>values from current theme are used.",
+        "The configuration for all text editors.\nIf `fontFamily`, `fontSize` or `lineHeight` are `null`,\nvalues from current theme are used.",
         "Text Editor Indentation",
         "Text Editor",
         "Editor",


### PR DESCRIPTION
This fixes https://github.com/jupyterlab/language-packs/issues/102

Running the update catalogs script, I did not encounter any error. The multi-lines strings from settings are now all store as multi-lines in the pot files like for code multi-lines strings.