### PR TITLE
fix: add -l option to usage example for the compile command as it won't do anything without it

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Visit the [language packs repository](https://github.com/jupyterlab/language-pac
 ```bash
 jupyterlab-translate extract <JLAB-EXTENSION-DIR> <JLAB-EXTENSION-NAME>
 jupyterlab-translate update <JLAB-EXTENSION-DIR> <JLAB-EXTENSION-NAME> -l es_ES
-jupyterlab-translate compile <JLAB-EXTENSION-DIR> <JLAB-EXTENSION-NAME>
+jupyterlab-translate compile <JLAB-EXTENSION-DIR> <JLAB-EXTENSION-NAME> -l es_ES
 ```
 
 ## Development


### PR DESCRIPTION
`jupyterlab-translate compile` does not do anything if no locale is specified. The loop in line 783 of utils.py will run 0-times if no locale is specified:

https://github.com/jupyterlab/jupyterlab-translate/blob/37e39f2a6521b89c6148c06436eede2c53e13d42/jupyterlab_translate/utils.py#L765-L786

For this reason the usage example should be changed to include the `-l` option.